### PR TITLE
Add JSONL reader/writer utilities

### DIFF
--- a/libs/jsonl_io.hpp
+++ b/libs/jsonl_io.hpp
@@ -1,0 +1,39 @@
+#pragma once
+#include <fstream>
+#include <string>
+#include <vector>
+#include <iterator>
+#include <stdexcept>
+
+namespace rapidwebsift {
+
+// Read a JSONL file line by line and invoke a callback for each line.
+template <typename Callback>
+void read_jsonl(const std::string& path, Callback cb, std::size_t buf_size = 1 << 16) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) {
+        throw std::runtime_error("Failed to open JSONL file for reading: " + path);
+    }
+    std::vector<char> buffer(buf_size);
+    in.rdbuf()->pubsetbuf(buffer.data(), buffer.size());
+    std::string line;
+    while (std::getline(in, line)) {
+        cb(line);
+    }
+}
+
+// Write objects to a JSONL file. Each object must be streamable via operator<<.
+template <typename Iterable>
+void write_jsonl(const std::string& path, const Iterable& objects, std::size_t buf_size = 1 << 16) {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out) {
+        throw std::runtime_error("Failed to open JSONL file for writing: " + path);
+    }
+    std::vector<char> buffer(buf_size);
+    out.rdbuf()->pubsetbuf(buffer.data(), buffer.size());
+    for (const auto& obj : objects) {
+        out << obj << '\n';
+    }
+}
+
+} // namespace rapidwebsift

--- a/tests/jsonl_io_test.cpp
+++ b/tests/jsonl_io_test.cpp
@@ -1,0 +1,21 @@
+#include "../libs/jsonl_io.hpp"
+#include <vector>
+#include <string>
+#include <iostream>
+
+int main() {
+    std::vector<std::string> lines = {"{\"a\":1}", "{\"b\":2}"};
+    rapidwebsift::write_jsonl("test_tmp.jsonl", lines);
+
+    std::vector<std::string> out;
+    rapidwebsift::read_jsonl("test_tmp.jsonl", [&](const std::string& l) {
+        out.push_back(l);
+    });
+
+    if (out != lines) {
+        std::cerr << "Mismatch after read/write" << std::endl;
+        return 1;
+    }
+    std::cout << "JSONL read/write success" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement a small header `jsonl_io.hpp` that provides helper functions to read and write JSONL files using buffered I/O
- add a simple test demonstrating the utilities

## Testing
- `g++ -std=c++17 tests/jsonl_io_test.cpp -o tests/jsonl_io_test && ./tests/jsonl_io_test`